### PR TITLE
Removing node modules from webpack build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "purecloud-streaming-client-webrtc-sessions",
+  "name": "genesys-cloud-streaming-client-webrtc-sessions",
   "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -10539,7 +10539,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
       "dev": true
     },
@@ -12983,6 +12983,12 @@
           }
         }
       }
+    },
+    "webpack-node-externals": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-2.5.0.tgz",
+      "integrity": "sha512-g7/Z7Q/gsP8GkJkKZuJggn6RSb5PvxW1YD5vvmRZIxaSxAzkqjfL5n9CslVmNYlSqBVCyiqFgOqVS2IOObCSRg==",
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-cloud-streaming-client-webrtc-sessions",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "WebRTC Extensions for the Genesys Cloud Streaming Client SDK",
   "main": "dist/webrtc-sessions.js",
   "pre-push": [
@@ -8,8 +8,7 @@
   ],
   "files": [
     "src",
-    "dist/webrtc-sessions.js",
-    "dist/webrtc-sessions.js.map"
+    "dist"
   ],
   "scripts": {
     "build": "webpack && webpack --env.production",
@@ -112,6 +111,7 @@
     "sinon": "^7.5.0",
     "watch": "^1.0.2",
     "webpack": "^4.35.3",
-    "webpack-cli": "^3.3.5"
+    "webpack-cli": "^3.3.5",
+    "webpack-node-externals": "^2.5.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const nodeExternals = require('webpack-node-externals');
 
 module.exports = (env) => {
   const minimize = env && env.production;
@@ -10,6 +11,7 @@ module.exports = (env) => {
     optimization: {
       minimize
     },
+    externals: [nodeExternals()],
     output: {
       path: path.resolve(__dirname, 'dist'),
       filename: minimize ? 'webrtc-sessions.min.js' : 'webrtc-sessions.js',
@@ -22,6 +24,7 @@ module.exports = (env) => {
         {
           test: /\.js$/,
           loader: 'babel-loader',
+          exclude: [/node_modules/],
           query: {
             presets: ['@babel/preset-env']
           }


### PR DESCRIPTION
This is just to remove the node_modules from being included in the webpack build/bundle. This project is only built for `target: 'node'` and doesn't have any transpiling of node_modules so I didn't see a reason to include them. 